### PR TITLE
feat(context): add shell script detection to collector (fixes #17)

### DIFF
--- a/context/collector.go
+++ b/context/collector.go
@@ -73,6 +73,22 @@ func Collect(repoRoot string, target *parser.Target) (*Collected, error) {
 			c.ProjectFiles[f] = string(data)
 		}
 	}
+// Include already-compiled scripts so LLM stays style-consistent
+	compiledDir := filepath.Join(repoRoot, ".vibe", "compiled")
+	if entries, err := os.ReadDir(compiledDir); err == nil {
+		for _, entry := range entries {
+			name := entry.Name()
+			if !entry.IsDir() && filepath.Ext(name) == ".sh" {
+				if name != target.Name+".sh" {
+					key := filepath.Join(".vibe", "compiled", name)
+					path := filepath.Join(compiledDir, name)
+					if data, err := os.ReadFile(path); err == nil {
+						c.ProjectFiles[key] = string(data)
+					}
+				}
+			}
+		}
+	}
 
 	if gitStatus, err := runGitStatus(repoRoot); err == nil {
 		c.GitStatus = gitStatus
@@ -104,6 +120,16 @@ func inferTaskFiles(target *parser.Target) []string {
 		files = append(files, "schema.sql", "schema.prisma", "prisma/schema.prisma")
 	}
 
+        // Include common shell scripts based on target name/recipe
+	commonShellScripts := []string{
+		"build.sh", "deploy.sh", "test.sh", "run.sh",
+		"setup.sh", "install.sh", "release.sh", "lint.sh", "ci.sh",
+	}
+	for _, script := range commonShellScripts {
+		if containsAny(combined, strings.TrimSuffix(script, ".sh")) {
+			files = append(files, script)
+		}
+	}
 	return files
 }
 

--- a/context/collector_test.go
+++ b/context/collector_test.go
@@ -153,3 +153,32 @@ func TestInferTaskFilesNoMatchReturnsEmpty(t *testing.T) {
 		t.Errorf("expected no inferred files, got %v", files)
 	}
 }
+func TestInferTaskFilesIncludesShellScripts(t *testing.T) {
+	target := &parser.Target{Name: "build", Recipe: "compile the app"}
+	files := inferTaskFiles(target)
+	found := false
+	for _, f := range files {
+		if f == "build.sh" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected build.sh to be included for build target")
+	}
+}
+
+func TestInferTaskFilesDeployIncludesDeploySh(t *testing.T) {
+	target := &parser.Target{Name: "deploy", Recipe: "deploy to fly.io"}
+	files := inferTaskFiles(target)
+	found := false
+	for _, f := range files {
+		if f == "deploy.sh" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected deploy.sh to be included for deploy target")
+	}
+}


### PR DESCRIPTION
## What this PR does
- Adds `.sh` script detection in `inferTaskFiles()` for common scripts like `build.sh`, `deploy.sh`, `test.sh` etc.
- Includes existing `.vibe/compiled/*.sh` scripts as context so the LLM stays style-consistent
- Skips the current target's own compiled script to avoid circular reference

## Changes
- `context/collector.go` — added shell script detection in `inferTaskFiles()` and compiled scripts inclusion in `Collect()`
- `context/collector_test.go` — added 2 new tests

## Tests added
- `TestInferTaskFilesIncludesShellScripts` — verifies `build.sh` is included for a build target
- `TestInferTaskFilesDeployIncludesDeploySh` — verifies `deploy.sh` is included for a deploy target

## Test output
All existing tests continue to pass.

Fixes #17